### PR TITLE
Add cleanup by age feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,8 +485,10 @@
 
     <!--
       To start a local mongo db and tomcat use:
-
         mvn -Plocal-dev com.github.joelittlejohn.embedmongo:embedmongo-maven-plugin:start org.codehaus.cargo:cargo-maven2-plugin:run
+
+      Or use maven executions:
+        mvn clean install -Plocal-dev -DskipTests=true
     -->
     <profile>
       <id>local-dev</id>
@@ -500,6 +502,14 @@
               <databaseDirectory>${project.build.directory}/mongo-dev</databaseDirectory>
               <logging>file</logging>
             </configuration>
+              <executions>
+                  <execution>
+                      <phase>install</phase>
+                      <goals>
+                          <goal>start</goal>
+                      </goals>
+                  </execution>
+              </executions>
           </plugin>
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
@@ -520,6 +530,14 @@
                 </deployable>
               </deployables>
             </configuration>
+              <executions>
+                  <execution>
+                      <phase>install</phase>
+                      <goals>
+                          <goal>run</goal>
+                      </goals>
+                  </execution>
+              </executions>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/de/is24/infrastructure/gridfs/http/domain/RepoEntry.java
+++ b/src/main/java/de/is24/infrastructure/gridfs/http/domain/RepoEntry.java
@@ -25,6 +25,8 @@ public class RepoEntry {
 
   public static final int DEFAULT_MAX_KEEP_RPMS = 1;
 
+  public static final int DEFAULT_MAX_DAYS_RPMS = 0;
+
   private RepoType type;
 
   private Date lastModified;
@@ -40,6 +42,8 @@ public class RepoEntry {
   private Set<String> tags = new HashSet<>();
 
   private int maxKeepRpms = DEFAULT_MAX_KEEP_RPMS;
+
+  private int maxDaysRpms = DEFAULT_MAX_DAYS_RPMS;
 
   private String hashOfEntries;
 
@@ -134,8 +138,16 @@ public class RepoEntry {
     return maxKeepRpms;
   }
 
+  public int getMaxDaysRpms() {
+    return maxDaysRpms;
+  }
+
   public void setMaxKeepRpms(int maxKeepRpms) {
     this.maxKeepRpms = maxKeepRpms;
+  }
+
+  public void setMaxDaysRpms(int maxDaysRpms) {
+    this.maxDaysRpms = maxDaysRpms;
   }
 
   public String getHashOfEntries() {
@@ -158,6 +170,7 @@ public class RepoEntry {
       .append("undeletable", undeletable)
       .append("tags", tags)
       .append("maxKeepRpms", maxKeepRpms)
+      .append("maxDaysRpms", maxDaysRpms)
       .append("hashOfEntries", hashOfEntries)
       .toString();
   }

--- a/src/main/java/de/is24/infrastructure/gridfs/http/repos/RepoService.java
+++ b/src/main/java/de/is24/infrastructure/gridfs/http/repos/RepoService.java
@@ -149,6 +149,18 @@ public class RepoService {
   }
 
   @ManagedOperation
+  public void setMaxDaysRpms(String reponame, int maxDaysRpms) {
+      if (maxDaysRpms < 0) {
+          throw new BadRequestException("You cannot keep RPMs for a negative amount of days");
+      }
+
+      RepoEntry repoEntry = ensureEntry(reponame, STATIC, SCHEDULED);
+      repoEntry.setMaxDaysRpms(maxDaysRpms);
+      entriesRepository.save(repoEntry);
+      LOG.info("Set maxDaysRpms of repository {} to {}", reponame, maxDaysRpms);
+  }
+
+  @ManagedOperation
   public void createVirtualRepo(String reponame, String destination) {
     validateRepoName(reponame);
 

--- a/src/main/java/de/is24/infrastructure/gridfs/http/web/controller/RepositoryController.java
+++ b/src/main/java/de/is24/infrastructure/gridfs/http/web/controller/RepositoryController.java
@@ -87,6 +87,13 @@ public class RepositoryController {
     repoService.setMaxKeepRpms(reponame, maxKeepRpms);
   }
 
+  @RequestMapping(value = "/{reponame}/maxDaysRpms", method = PUT)
+  @ResponseStatus(NO_CONTENT)
+  public void updateMaxDaysRpms(@PathVariable("reponame") String reponame, @RequestBody
+                               int maxDaysRpms) {
+    repoService.setMaxDaysRpms(reponame, maxDaysRpms);
+  }
+
   @RequestMapping(method = POST)
   @ResponseStatus(CREATED)
   public void createStaticRepository(@RequestParam("name") String reponame) {

--- a/src/main/webapp/WEB-INF/jsp/staticRepoInfo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/staticRepoInfo.jsp
@@ -3,7 +3,7 @@
 <%@ taglib prefix="tags" tagdir="/WEB-INF/tags" %>
 <%--@elvariable id="repo" type="de.is24.infrastructure.gridfs.http.domain.RepoEntry"--%>
 <div>
-    <ul class="tablelist name-value-pairs">
+    <ul class="tableList">
         <li>
             <span class="label">Name</span>
             <span class="value" id="yumRepoName" name="${repo.name}">${repo.name}</span>
@@ -23,11 +23,15 @@
             <span class="value"><tags:date date="${repo.lastMetadataGeneration}" /></span>
         </li>
         <li>
-          <span class="label">Max. Keep RPMs</span>
-          <span class="value"><span id="maxKeepRpmsValue" name="${repo.name}">${repo.maxKeepRpms}</span><div id="maxKeepRpmsSlider"></div></span>
+            <span class="label">Max. Keep RPMs</span>
+            <span class="value long"><span id="maxKeepRpmsValue" name="${repo.name}">${repo.maxKeepRpms}</span><div id="maxKeepRpmsSlider"></div></span>
         </li>
         <li>
-		      <span class="label thin">Tags</span>
+            <span class="label">Max. Days RPMs</span>
+            <span class="value long"><span id="maxDaysRpmsValue" name="${repo.name}">${repo.maxDaysRpms}</span><div id="maxDaysRpmsSlider"></div></span>
+        </li>
+        <li>
+		  <span class="label thin">Tags</span>
           <span>
             <span id="tags" style="display:none"><c:forEach items="${repo.tags}" var="tag"><span class="tag" style="margin-right:5px">${tag}</span></c:forEach></span>
             <input id="tagsInput" type="text" />

--- a/src/main/webapp/static/css/index.css
+++ b/src/main/webapp/static/css/index.css
@@ -331,8 +331,16 @@ span.value .ui-switchbutton.ui-state-active {
     margin-left: 20px;
 }
 
+#maxDaysRpmsValue {
+    margin-left: 20px;
+}
+
 #maxKeepRpmsSlider {
-    margin: 9px 0 0 50px;
+    margin: 9px 0 0 90px;
+}
+
+#maxDaysRpmsSlider {
+    margin: 9px 0 0 90px;
 }
 
 .versionInfo {

--- a/src/main/webapp/static/js/yum.js
+++ b/src/main/webapp/static/js/yum.js
@@ -81,6 +81,10 @@ window.yum = {
     yum.setRepoProperty(reponame, 'maxKeepRpms', value);
   },
 
+  setMaxDaysRpms : function(reponame, value) {
+    yum.setRepoProperty(reponame, 'maxDaysRpms', value);
+  },
+
   setRepoProperty : function(reponame, property, value) {
     $.ajax({
       type : 'PUT',
@@ -132,6 +136,25 @@ window.yum = {
       });
       if ( keepRpmsValue.text() === 0){
           keepRpmsValue.text("ALL");
+      }
+
+      var daysRpmsSlider = $('#maxDaysRpmsSlider');
+      var daysRpmsValue = $('#maxDaysRpmsValue');
+      daysRpmsSlider.slider({
+        min: 0,
+        max: 30,
+        value: daysRpmsValue.text(),
+        slide: function( event, ui ) {
+            var value = ui.value;
+            if ( value == 0){
+                value = "NEVER";
+            }
+            daysRpmsValue.text(value);
+          yum.setMaxDaysRpms(daysRpmsValue.attr('name'), ui.value);
+        }
+      });
+      if ( daysRpmsValue.text() == 0){
+          daysRpmsValue.text("NEVER");
       }
   },
 

--- a/src/test/java/de/is24/infrastructure/gridfs/http/web/controller/RepositoryControllerIT.java
+++ b/src/test/java/de/is24/infrastructure/gridfs/http/web/controller/RepositoryControllerIT.java
@@ -21,6 +21,7 @@ import org.springframework.data.mongodb.repository.support.MongoRepositoryFactor
 
 import java.io.IOException;
 
+import static de.is24.infrastructure.gridfs.http.domain.RepoEntry.DEFAULT_MAX_DAYS_RPMS;
 import static de.is24.infrastructure.gridfs.http.domain.RepoEntry.DEFAULT_MAX_KEEP_RPMS;
 import static de.is24.infrastructure.gridfs.http.domain.RepoType.SCHEDULED;
 import static de.is24.infrastructure.gridfs.http.mongo.IntegrationTestContext.mongoTemplate;
@@ -107,6 +108,13 @@ public class RepositoryControllerIT extends AbstractContainerAndMongoDBStarter {
   }
 
   @Test
+  public void modifyMaxDaysRpms() throws Exception {
+    RepoEntry repoEntry = updateRepoEntry("/maxDaysRpms", "3");
+    assertThat(repoEntry, notNullValue());
+    assertThat(repoEntry.getMaxDaysRpms(), is(3));
+  }
+
+  @Test
   public void createStaticRepo() throws Exception {
     String reponame = uniqueRepoName();
     HttpPost post = new HttpPost(deploymentURL + "/repo/");
@@ -119,6 +127,7 @@ public class RepositoryControllerIT extends AbstractContainerAndMongoDBStarter {
 
     assertFalse(isEmpty(repoEntriesRepository.findByName(reponame)));
     thenMaxKeepRpmsHasDefaultValue(reponame);
+    thenMaxDaysRpmsHasDefaultValue(reponame);
   }
 
   private RepoEntry updateRepoEntry(String propertyUrl, String entity) throws IOException {
@@ -138,6 +147,9 @@ public class RepositoryControllerIT extends AbstractContainerAndMongoDBStarter {
     assertThat(repoEntriesRepository.findByName(reponame).get(0).getMaxKeepRpms(), is(DEFAULT_MAX_KEEP_RPMS));
   }
 
+  private void thenMaxDaysRpmsHasDefaultValue(String reponame) {
+    assertThat(repoEntriesRepository.findByName(reponame).get(0).getMaxDaysRpms(), is(DEFAULT_MAX_DAYS_RPMS));
+  }
 
   private void thenStatusCreatedForEntity(HttpEntity entity) throws IOException {
     HttpPost post = new HttpPost(deploymentURL + "/repo/" + uniqueRepoName());


### PR DESCRIPTION
This will allow a repo to have a cleanup by rpm build age option.

The idea behind it is that due to having a very large number of rpm builds being generated every day you might want to specify a max number days for rotation of each package instead of the max number of builds of the package.

In practice the cleanup method now performs both cleanup methods using a binary OR operation.

Changed the interface to have 2 sliders for each option with a 30 days max for the new cleanup by age method and set the cleanup by age default to 0 (NEVER) so that the same behaviour as before is maintained by default.

![screenshot 2014-08-19 00 29 59](https://cloud.githubusercontent.com/assets/994805/3959602/be31359e-272f-11e4-9a35-dfd83c6d0ef8.png)

Added/Updated the tests suite to reflect changes.
