### PR TITLE
embedmongo download improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ ve
 # ignore eclipse project files
 /.pydevproject
 /.project
+
+# embedded mongo for testing
+embedmongo.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,25 +3,10 @@ dist
 deb_dist
 !.gitignore
 target
-*.pyc
-*.egg-info
 *.iml
 *~
 
-# ignoe virtualenv ve
-/ve
-
-# ignoring coverage data file
-.coverage
-
-# ignoring pycharm meta data
-.idea
-
-# ignoring virtual environment directory
-ve
-
 # ignore eclipse project files
-/.pydevproject
 /.project
 
 # embedded mongo for testing

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ deb_dist
 !.gitignore
 target
 *.iml
+.idea
 *~
 
 # ignore eclipse project files

--- a/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
+++ b/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
@@ -36,7 +36,7 @@ public class LocalMongoFactory {
       new DownloadConfigBuilder() //
       .defaultsForCommand(MongoD) //
       .progressListener(new LoggingProgressListener(LOGGER, Level.INFO)) //
-      .downloadPath("http://fastdl.mongodb.org/") //
+      .downloadPath("https://fastdl.mongodb.org/") //
       .artifactStorePath(MONGO_DOWNLOAD_FOLDER); //
     de.flapdoodle.embed.process.store.ArtifactStoreBuilder download =
       new ArtifactStoreBuilder() //

--- a/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
+++ b/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
@@ -27,7 +27,7 @@ import static de.is24.infrastructure.gridfs.http.utils.retry.RetryUtils.execute;
 public class LocalMongoFactory {
   private static final String TEMP_DIR = new PlatformTempDir().asFile().getAbsolutePath();
   @VisibleForTesting
-  static final FixedPath MONGO_DOWNLOAD_FOLDER = new FixedPath(TEMP_DIR + File.separator + ".embedded-mongo");
+  static final FixedPath MONGO_DOWNLOAD_FOLDER = new FixedPath(TEMP_DIR + File.separator + "embedded-mongo");
   private static final Logger LOGGER = Logger.getLogger(LocalMongoFactory.class.getCanonicalName());
 
   @VisibleForTesting

--- a/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
+++ b/src/test/java/de/is24/infrastructure/gridfs/http/mongo/util/LocalMongoFactory.java
@@ -11,6 +11,9 @@ import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.store.HttpProxyFactory;
+import de.flapdoodle.embed.process.config.store.IProxyFactory;
+import de.flapdoodle.embed.process.config.store.NoProxyFactory;
 import de.flapdoodle.embed.process.io.directories.FixedPath;
 import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
 import de.flapdoodle.embed.process.io.progress.LoggingProgressListener;
@@ -37,6 +40,7 @@ public class LocalMongoFactory {
       .defaultsForCommand(MongoD) //
       .progressListener(new LoggingProgressListener(LOGGER, Level.INFO)) //
       .downloadPath("https://fastdl.mongodb.org/") //
+      .proxyFactory(proxyForEnvironment()) //
       .artifactStorePath(MONGO_DOWNLOAD_FOLDER); //
     de.flapdoodle.embed.process.store.ArtifactStoreBuilder download =
       new ArtifactStoreBuilder() //
@@ -48,6 +52,19 @@ public class LocalMongoFactory {
       .defaultsWithLogger(MongoD, LOGGER) //
       .artifactStore(download).build();
     return MongodStarter.getInstance(runtimeConfig);
+  }
+
+  private static IProxyFactory proxyForEnvironment() {
+    if (isHttpProxyEnabled()) {
+       return new HttpProxyFactory(System.getProperty("http.proxyHost"), Integer.valueOf(System.getProperty("http.proxyPort")));
+    }
+    else {
+      return new NoProxyFactory();
+    }
+  }
+
+  private static boolean isHttpProxyEnabled() {
+    return System.getProperty("http.proxyHost") != null && System.getProperty("http.proxyPort") != null;
   }
 
   public static MongoProcessHolder createMongoProcess() throws Throwable {


### PR DESCRIPTION
* embedmongo download through HTTPS instead of HTTP
* passthrough proxy settings for embedmongo download (resolves #61)
* avoid hiding the embedded mongo download in /tmp
* gitignore tuning

I can squash this if you want, though the current state would allow cherry-picking or selectively reverting stuff.